### PR TITLE
feat: add support for custom github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
 | Input                 | Description                                                                                             | Required | Default                           |
 | --------------------- | ------------------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
 | `github-token`        | GitHub token for posting comments                                                                       | No       | `${{ github.token }}`             |
+| `github-url`          | GitHub URL to be used for running an action                                                             | No       | `https://github.com`              |
 | `github-issue-number` | GitHub issue number where the status comment will be posted                                             | No       | Current issue from GitHub context |
 | `github-username`     | GitHub username of the user for whom the workspace is being started (requires Coder 2.21 or newer)      | No       | -                                 |
 | `coder-username`      | Coder username to override default user mapping (only set one of `github-username` or `coder-username`) | No       | -                                 |

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'GitHub token for posting the status comment'
     required: false
     default: ${{ github.token }}
+  github-url:
+    description: 'GitHub URL to be used for running an action'
+    required: false
+    default: 'https://github.com'
   github-issue-number:
     description: 'GitHub issue number where the status comment will be posted (defaults to current issue context)'
     required: false
@@ -44,7 +48,7 @@ runs:
             core.setFailed('No issue number provided and no issue context available');
             return;
           }
-          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const runUrl = `${{ inputs.github-url }}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const comment = await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
This change is adding support for custom GitHub URL value (e.g., to support Enterprise GitHub URLs). It is backwards compatible with the previous version and uses the same default as before.