### PR TITLE
feat: partial support for github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ jobs:
 | Input                 | Description                                                                                             | Required | Default                           |
 | --------------------- | ------------------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
 | `github-token`        | GitHub token for posting comments                                                                       | No       | `${{ github.token }}`             |
-| `github-url`          | URL of the GitHub instance to use                                                                       | No       | `https://github.com`              |
 | `github-issue-number` | GitHub issue number where the status comment will be posted                                             | No       | Current issue from GitHub context |
 | `github-username`     | GitHub username of the user for whom the workspace is being started (requires Coder 2.21 or newer)      | No       | -                                 |
 | `coder-username`      | Coder username to override default user mapping (only set one of `github-username` or `coder-username`) | No       | -                                 |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ jobs:
 | Input                 | Description                                                                                             | Required | Default                           |
 | --------------------- | ------------------------------------------------------------------------------------------------------- | -------- | --------------------------------- |
 | `github-token`        | GitHub token for posting comments                                                                       | No       | `${{ github.token }}`             |
+| `github-url`          | URL of the GitHub instance to use                                                                       | No       | `https://github.com`              |
 | `github-issue-number` | GitHub issue number where the status comment will be posted                                             | No       | Current issue from GitHub context |
 | `github-username`     | GitHub username of the user for whom the workspace is being started (requires Coder 2.21 or newer)      | No       | -                                 |
 | `coder-username`      | Coder username to override default user mapping (only set one of `github-username` or `coder-username`) | No       | -                                 |

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ jobs:
 
 This ensures the Coder API token is only accessible to workflows running on approved branches.
 
+## GitHub Enterprise Support
+
+This action supports GitHub Enterprise with the exception of the `github-username` input. You can use the `coder-username` input instead.
+
 ## License
 
 [MIT](LICENSE)

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,6 @@ inputs:
     description: 'GitHub token for posting the status comment'
     required: false
     default: ${{ github.token }}
-  github-url:
-    description: 'URL of the GitHub instance to use'
-    required: false
-    default: 'https://github.com'
   github-issue-number:
     description: 'GitHub issue number where the status comment will be posted (defaults to current issue context)'
     required: false
@@ -43,14 +39,13 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
-          const rawGithubUrl = '${{ inputs.github-url }}';
-          const githubUrl = rawGithubUrl.endsWith("/") ? rawGithubUrl.slice(0, -1) : rawGithubUrl;
           const issueNumber = '${{ inputs.github-issue-number }}' ? Number('${{ inputs.github-issue-number }}') : context.issue.number;
           if (!issueNumber) {
             core.setFailed('No issue number provided and no issue context available');
             return;
           }
-          const runUrl = `${githubUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const serverUrl = '${{ github.server_url }}';
+          const runUrl = `${serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const comment = await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -62,7 +57,7 @@ runs:
           core.setOutput('repo_owner', context.repo.owner);
           core.setOutput('repo_name', context.repo.repo);
           core.setOutput('issue_number', issueNumber);
-          core.setOutput('github_url', github.request.endpoint.DEFAULTS.baseUrl);
+          core.setOutput('github_url', '${{ github.api_url }}');
 
     - name: Start workspace
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
             core.setFailed('No issue number provided and no issue context available');
             return;
           }
-          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const runUrl = `${githubUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const comment = await github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
@@ -62,7 +62,7 @@ runs:
           core.setOutput('repo_owner', context.repo.owner);
           core.setOutput('repo_name', context.repo.repo);
           core.setOutput('issue_number', issueNumber);
-          core.setOutput('github_url', githubUrl);
+          core.setOutput('github_url', github.request.endpoint.DEFAULTS.baseUrl);
 
     - name: Start workspace
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'GitHub token for posting the status comment'
     required: false
     default: ${{ github.token }}
+  github-url:
+    description: 'URL of the GitHub instance to use'
+    required: false
+    default: 'https://github.com'
   github-issue-number:
     description: 'GitHub issue number where the status comment will be posted (defaults to current issue context)'
     required: false
@@ -39,6 +43,8 @@ runs:
       with:
         github-token: ${{ inputs.github-token }}
         script: |
+          const rawGithubUrl = '${{ inputs.github-url }}';
+          const githubUrl = rawGithubUrl.endsWith("/") ? rawGithubUrl.slice(0, -1) : rawGithubUrl;
           const issueNumber = '${{ inputs.github-issue-number }}' ? Number('${{ inputs.github-issue-number }}') : context.issue.number;
           if (!issueNumber) {
             core.setFailed('No issue number provided and no issue context available');
@@ -56,6 +62,7 @@ runs:
           core.setOutput('repo_owner', context.repo.owner);
           core.setOutput('repo_name', context.repo.repo);
           core.setOutput('issue_number', issueNumber);
+          core.setOutput('github_url', githubUrl);
 
     - name: Start workspace
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,6 @@ runs:
           core.setOutput('repo_owner', context.repo.owner);
           core.setOutput('repo_name', context.repo.repo);
           core.setOutput('issue_number', issueNumber);
-          core.setOutput('github_url', '${{ github.api_url }}');
 
     - name: Start workspace
       shell: bash
@@ -75,6 +74,7 @@ runs:
         GITHUB_WORKFLOW_RUN_URL: ${{ steps.initial-comment.outputs.run_url }}
         TEMPLATE_NAME: ${{ inputs.template-name }}
         WORKSPACE_PARAMETERS: ${{ inputs.parameters }}
+        GITHUB_URL: ${{ github.api_url }}
       run: |
         node "${{ github.action_path }}/dist/index.js"
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,4 @@
-// Source hash: 502e316a739f1716d693e20b5f00db3e1fec499dd7ae21b8777097eb429691e8
+// Source hash: 67ce94766a35d0d05fa9b4d38675d2f4deff7b82278c094b42d55ed2dfba6572
 import { createRequire } from "node:module";
 var __create = Object.create;
 var __getProtoOf = Object.getPrototypeOf;
@@ -30481,7 +30481,8 @@ var ActionInputSchema = z.object({
   githubToken: z.string().min(1),
   githubWorkflowRunUrl: z.string().min(1),
   templateName: z.string().min(1),
-  workspaceParameters: z.string().min(1)
+  workspaceParameters: z.string().min(1),
+  githubUrl: z.string().min(1)
 });
 var WorkspaceParametersSchema = z.record(z.string(), z.string());
 
@@ -30493,7 +30494,10 @@ class StartWorkspaceAction {
   constructor(logger, input) {
     this.logger = logger;
     this.input = input;
-    this.octokit = new Octokit2({ auth: input.githubToken });
+    this.octokit = new Octokit2({
+      auth: input.githubToken,
+      baseUrl: input.githubUrl
+    });
     this.coder = new CoderClient(input.coderUrl, input.coderToken);
   }
   async coderUsernameByGitHubId(githubUserId) {
@@ -30625,7 +30629,8 @@ var main = async () => {
     githubToken: "GITHUB_TOKEN",
     githubWorkflowRunUrl: "GITHUB_WORKFLOW_RUN_URL",
     templateName: "TEMPLATE_NAME",
-    workspaceParameters: "WORKSPACE_PARAMETERS"
+    workspaceParameters: "WORKSPACE_PARAMETERS",
+    githubUrl: "GITHUB_URL"
   };
   const input = ActionInputSchema.parse(Object.fromEntries(Object.entries(inputEnv).map(([key, value]) => [
     key,

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -3,7 +3,6 @@ import {
   StartWorkspaceAction,
   UserFacingError,
   type ActionInput,
-  type ExecOutput,
   type Logger,
 } from "./action";
 import dedent from "dedent";
@@ -31,30 +30,6 @@ interface ActionParams {
 }
 
 const newAction = (params?: ActionParams) => {
-  const defaults: ActionInput = {
-    githubUsername: "github-user",
-    coderUsername: "coder-user",
-    coderUrl: "https://example.com",
-    coderToken: "coder-token",
-    workspaceName: "workspace-name",
-    githubStatusCommentId: 123,
-    githubRepoOwner: "github-repo-owner",
-    githubRepoName: "github-repo-name",
-    githubToken: "github-token",
-    githubWorkflowRunUrl: "https://github.com/workflow-run",
-    templateName: "ubuntu",
-    workspaceParameters: dedent`
-      key: value
-      key2: value2
-      key3: value3
-    `.trim(),
-  };
-  // Loop through the input rather than use {...defaults, ...(params?.input ?? {})}
-  // to also allow overriding defaults with undefined values
-  for (const [key, value] of Object.entries(params?.input ?? {})) {
-    (defaults as any)[key] = value;
-  }
-
   const action = new StartWorkspaceAction(params?.logger ?? new TestLogger(), {
     githubUsername: "github-user",
     coderUsername: undefined,
@@ -72,21 +47,11 @@ const newAction = (params?: ActionParams) => {
         key2: value2
         key3: value3
       `.trim(),
+    githubUrl: "https://github.com",
     ...(params?.input ?? {}),
   });
 
   return action;
-};
-
-const identityExec = async (
-  strings: TemplateStringsArray,
-  ...args: unknown[]
-): Promise<ExecOutput> => {
-  let result = strings[0];
-  for (let i = 0; i < args.length; i++) {
-    result += String(args[i]) + strings[i + 1];
-  }
-  return { text: () => result ?? "" };
 };
 
 describe("StartWorkspaceAction", () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -41,6 +41,7 @@ export const ActionInputSchema = z.object({
   githubWorkflowRunUrl: z.string().min(1),
   templateName: z.string().min(1),
   workspaceParameters: z.string().min(1),
+  githubUrl: z.string().min(1),
 });
 
 export type ActionInput = z.infer<typeof ActionInputSchema>;
@@ -56,7 +57,10 @@ export class StartWorkspaceAction {
     private readonly logger: Logger,
     private readonly input: ActionInput
   ) {
-    this.octokit = new Octokit({ auth: input.githubToken });
+    this.octokit = new Octokit({
+      auth: input.githubToken,
+      baseUrl: input.githubUrl,
+    });
     this.coder = new CoderClient(input.coderUrl, input.coderToken);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ const main = async () => {
     githubWorkflowRunUrl: "GITHUB_WORKFLOW_RUN_URL",
     templateName: "TEMPLATE_NAME",
     workspaceParameters: "WORKSPACE_PARAMETERS",
+    githubUrl: "GITHUB_URL",
   };
 
   const input = ActionInputSchema.parse(


### PR DESCRIPTION
Supersedes https://github.com/coder/start-workspace-action/pull/3. Adds support for GitHub Enterprise with the exception of the `github-username` input - it's blocked by https://github.com/coder/coder/issues/18828.